### PR TITLE
Reg ex

### DIFF
--- a/Sources/NetworkingTestSupport/TestURLSession.swift
+++ b/Sources/NetworkingTestSupport/TestURLSession.swift
@@ -105,7 +105,7 @@ public struct TestURLSessionConfiguration {
         for (key, value) in matchingConfig where
             key.method.name == method &&
             key.host == components.host &&
-            key.path ~= components.path &&
+            components.path ~= key.path &&
             key.query?.count == components.queryItems?.count {
 
             var fullMatch = true

--- a/Sources/NetworkingTestSupport/TestURLSession.swift
+++ b/Sources/NetworkingTestSupport/TestURLSession.swift
@@ -105,7 +105,7 @@ public struct TestURLSessionConfiguration {
         for (key, value) in matchingConfig where
             key.method.name == method &&
             key.host == components.host &&
-            key.path == components.path &&
+            key.path ~= components.path &&
             key.query?.count == components.queryItems?.count {
 
             var fullMatch = true
@@ -347,5 +347,13 @@ extension HTTP.Method {
         case .trace:
             return "TRACE"
         }
+    }
+}
+
+extension String {
+    static func ~= (lhs: String, rhs: String) -> Bool {
+        guard let regex = try? NSRegularExpression(pattern: rhs) else { return false }
+        let range = NSRange(location: 0, length: lhs.utf16.count)
+        return regex.firstMatch(in: lhs, options: [], range: range) != nil
     }
 }

--- a/Sources/NetworkingTestSupport/TestURLSession.swift
+++ b/Sources/NetworkingTestSupport/TestURLSession.swift
@@ -350,7 +350,7 @@ extension HTTP.Method {
     }
 }
 
-extension String {
+private extension String {
     static func ~= (lhs: String, rhs: String) -> Bool {
         guard let regex = try? NSRegularExpression(pattern: rhs) else { return false }
         let range = NSRange(location: 0, length: lhs.utf16.count)


### PR DESCRIPTION
enables to use a regular expression to match path component, which means can match a path including an API Key without having to reveal key or import main project into test.